### PR TITLE
[Refactor] recover position relative information to support phrase query

### DIFF
--- a/src/core/CLucene/index/DocumentsWriter.cpp
+++ b/src/core/CLucene/index/DocumentsWriter.cpp
@@ -552,7 +552,15 @@ void DocumentsWriter::writeSegment(std::vector<std::string>& flushedFiles) {
                                                  writer->getTermIndexInterval());
 
   IndexOutput* freqOut = directory->createOutput( (segmentName + ".frq").c_str() );
-  IndexOutput* proxOut = nullptr;
+  // Only create the prox stream when at least one indexed field still
+  // stores positions. When IndexWriter::setOmitPositions(true) is in effect
+  // hasProx() returns false and the .prx file is never produced for this
+  // segment; downstream code (appendPostings, skip list writer, segment
+  // reader) all check for a null proxOut/proxStream.
+  const bool segmentHasProx = fieldInfos->hasProx();
+  IndexOutput* proxOut = segmentHasProx
+      ? directory->createOutput( (segmentName + ".prx").c_str() )
+      : NULL;
 
   // Gather all FieldData's that have postings, across all
   // ThreadStates
@@ -602,6 +610,10 @@ void DocumentsWriter::writeSegment(std::vector<std::string>& flushedFiles) {
 
   freqOut->close();
   _CLDELETE(freqOut);
+  if (proxOut != NULL) {
+    proxOut->close();
+    _CLDELETE(proxOut);
+  }
   termsOut->close();
   _CLDELETE(termsOut);
   _CLDELETE(skipListWriter);
@@ -609,6 +621,10 @@ void DocumentsWriter::writeSegment(std::vector<std::string>& flushedFiles) {
   // Record all files we have flushed
   flushedFiles.push_back(segmentFileName(IndexFileNames::FIELD_INFOS_EXTENSION));
   flushedFiles.push_back(segmentFileName(IndexFileNames::FREQ_EXTENSION));
+  // Only advertise the .prx file when we actually produced one; the
+  // compound-file builder consumes this list verbatim.
+  if (segmentHasProx)
+    flushedFiles.push_back(segmentFileName(IndexFileNames::PROX_EXTENSION));
   flushedFiles.push_back(segmentFileName(IndexFileNames::TERMS_EXTENSION));
   flushedFiles.push_back(segmentFileName(IndexFileNames::TERMS_INDEX_EXTENSION));
 
@@ -681,6 +697,14 @@ void DocumentsWriter::appendPostings(ArrayBase<ThreadState::FieldData*>* fields,
   const int32_t fieldNumber = (*fields)[0]->fieldInfo->number;
   int32_t numFields = fields->length;
 
+  // If the field has omitPositions=true we will not touch proxOut at all,
+  // even if a prox stream was opened for the segment (some other field has
+  // positions). The skip list writer also gets its prox tracking disabled
+  // via the curStorePayloads/proxOutput nullability path.
+  const bool fieldOmitPositions =
+      (*fields)[0]->fieldInfo != NULL && (*fields)[0]->fieldInfo->omitPositions;
+  IndexOutput* const effectiveProxOut = fieldOmitPositions ? NULL : proxOut;
+
   ObjectArray<FieldMergeState> mergeStatesData(numFields);
   ValueArray<FieldMergeState*> mergeStates(numFields);
 
@@ -698,7 +722,9 @@ void DocumentsWriter::appendPostings(ArrayBase<ThreadState::FieldData*>* fields,
   memcpy(mergeStates.values,mergeStatesData.values,sizeof(FieldMergeState*) * numFields);
 
   const int32_t skipInterval = termsOut->skipInterval;
-  currentFieldStorePayloads = (*fields)[0]->fieldInfo->storePayloads;
+  // Payload storage and prox are mutually exclusive with omitPositions: a
+  // field cannot store payloads if it does not store positions.
+  currentFieldStorePayloads = fieldOmitPositions ? false : (*fields)[0]->fieldInfo->storePayloads;
 
   ValueArray<FieldMergeState*> termStates(numFields);
 
@@ -731,7 +757,10 @@ void DocumentsWriter::appendPostings(ArrayBase<ThreadState::FieldData*>* fields,
       pos++;
 
     int64_t freqPointer = freqOut->getFilePointer();
-    int64_t proxPointer = 0;
+    // When this field omits positions there is no prox stream to track, so
+    // we record 0 as the proxPointer in TermInfo and SkipListWriter ignores
+    // its proxOutput. The reader side reconstructs the same null behavior.
+    int64_t proxPointer = (effectiveProxOut != NULL) ? effectiveProxOut->getFilePointer() : 0;
 
     skipListWriter->resetSkip();
 
@@ -760,6 +789,36 @@ void DocumentsWriter::appendPostings(ArrayBase<ThreadState::FieldData*>* fields,
       lastDoc = doc;
 
       ByteSliceReader& prox = minState->prox;
+
+      // Carefully copy over the prox + payload info,
+      // changing the format to match Lucene's segment
+      // format.
+      // When the field omits positions, addPosition never wrote a prox
+      // slice, so the reader is empty and there is nothing to copy.
+      if (effectiveProxOut != NULL) {
+        for(int32_t j=0;j<termDocFreq;j++) {
+          const int32_t code = prox.readVInt();
+          if (currentFieldStorePayloads) {
+            int32_t payloadLength;
+            if ((code & 1) != 0) {
+              // This position has a payload
+              payloadLength = prox.readVInt();
+            } else
+              payloadLength = 0;
+            if (payloadLength != lastPayloadLength) {
+              effectiveProxOut->writeVInt(code|1);
+              effectiveProxOut->writeVInt(payloadLength);
+              lastPayloadLength = payloadLength;
+            } else
+              effectiveProxOut->writeVInt(code & (~1));
+            if (payloadLength > 0)
+              copyBytes(&prox, effectiveProxOut, payloadLength);
+          } else {
+            assert ( 0 == (code & 1) );
+            effectiveProxOut->writeVInt(code>>1);
+          }
+        }
+      }
 
       if (1 == termDocFreq) {
         freqOut->writeVInt(newDocCode|1);
@@ -1396,6 +1455,13 @@ bool DocumentsWriter::FieldMergeState::nextTerm(){
   else
     freq.bufferOffset = freq.upto = freq.endIndex = 0;
 
+  // When the field omits positions, no prox slice was ever allocated for
+  // this posting (proxStart == proxUpto == 0). Skip the slice-reader
+  // initialization so we don't dereference an unallocated byte block.
+  if (p->proxUpto > p->proxStart)
+    prox.init(field->threadState->postingsPool, p->proxStart, p->proxUpto);
+  else
+    prox.bufferOffset = prox.upto = prox.endIndex = 0;
   // Should always be true
   bool result = nextDoc();
   assert (result);

--- a/src/core/CLucene/index/DocumentsWriterThreadState.cpp
+++ b/src/core/CLucene/index/DocumentsWriterThreadState.cpp
@@ -200,12 +200,18 @@ void DocumentsWriter::ThreadState::init(Document* doc, int32_t docID) {
   // seen before (eg suddenly turning on norms or
   // vectors, etc.):
 
+  // Resolve the writer-level omit-positions setting once per document init.
+  // This is intentionally sticky across the segment: callers cannot toggle
+  // it after addDocument(), which IndexWriter::setOmitPositions enforces.
+  const bool omitPositionsForWriter = _parent->writer->getOmitPositions();
+
   for(int32_t i=0;i<numDocFields;i++) {
     Field* field = docFields[i];
 
     FieldInfo* fi = _parent->fieldInfos->add(field->name(), field->isIndexed(), field->isTermVectorStored(),
                                   field->isStorePositionWithTermVector(), field->isStoreOffsetWithTermVector(),
-                                  field->getOmitNorms(), false);
+                                  field->getOmitNorms(), /*storePayloads*/ false,
+                                  /*omitPositions*/ omitPositionsForWriter);
     if (fi->isIndexed && !fi->omitNorms) {
       // Maybe grow our buffered norms
       if (_parent->norms.length <= fi->number) {
@@ -1022,6 +1028,12 @@ void DocumentsWriter::ThreadState::FieldData::addPosition(Token* token) {
 
   const Payload* payload = token->getPayload();
 
+  // When this field has omitPositions=true we skip every interaction with
+  // the prox byte stream: no slice allocation, no writeProx*, no payload
+  // capture. The freq stream and term-vector code paths are unaffected so
+  // TermQuery and term-vector consumers continue to work normally.
+  const bool fieldOmitPositions = (fieldInfo != NULL && fieldInfo->omitPositions);
+
   // Get the text of this term.  Term can either
   // provide a String token or offset into a TCHAR*
   // array
@@ -1096,6 +1108,8 @@ void DocumentsWriter::ThreadState::FieldData::addPosition(Token* token) {
           }
         }
 
+        proxCode = position;
+
         threadState->p->docFreq = 1;
 
         // Store code so we can write this after we're
@@ -1107,6 +1121,8 @@ void DocumentsWriter::ThreadState::FieldData::addPosition(Token* token) {
          //std::cout << "    seen before (same docID=" << threadState->docID << ") proxUpto=" << threadState->p->proxUpto << "\n";
 
         threadState->p->docFreq++;
+
+        proxCode = position - threadState->p->lastPosition;
 
         if (doVectors) {
           threadState->vector = threadState->p->vector;
@@ -1174,6 +1190,14 @@ void DocumentsWriter::ThreadState::FieldData::addPosition(Token* token) {
       const int32_t upto1 = threadState->postingsPool->newSlice(firstSize);
       threadState->p->freqStart = threadState->p->freqUpto = threadState->postingsPool->tOffset + upto1;
 
+      // Only allocate prox bytes when this field actually stores positions.
+      if (!fieldOmitPositions) {
+        const int32_t upto2 = threadState->postingsPool->newSlice(firstSize);
+        threadState->p->proxStart = threadState->p->proxUpto = threadState->postingsPool->tOffset + upto2;
+      } else {
+        threadState->p->proxStart = threadState->p->proxUpto = 0;
+      }
+
       threadState->p->lastDocCode = threadState->docID << 1;
       threadState->p->lastDocID = threadState->docID;
       threadState->p->docFreq = 1;
@@ -1185,7 +1209,27 @@ void DocumentsWriter::ThreadState::FieldData::addPosition(Token* token) {
           offsetEnd = offset + token->endOffset();
         }
       }
+   
+      proxCode = position;
     }
+
+    if (!fieldOmitPositions) {
+      threadState->proxUpto = threadState->p->proxUpto & BYTE_BLOCK_MASK;
+      threadState->prox = threadState->postingsPool->buffers[threadState->p->proxUpto >> BYTE_BLOCK_SHIFT];
+      assert (threadState->prox != NULL);
+
+      if (payload != NULL && payload->length() > 0) {
+        threadState->writeProxVInt((proxCode<<1)|1);
+        threadState->writeProxVInt(payload->length());
+        threadState->writeProxBytes(payload->getData().values, payload->getOffset(), payload->length());
+        fieldInfo->storePayloads = true;
+      } else
+        threadState->writeProxVInt(proxCode<<1);
+
+      threadState->p->proxUpto = threadState->proxUpto + (threadState->p->proxUpto & BYTE_BLOCK_NOT_MASK);
+    }
+    // proxCode is intentionally unused when positions are omitted; the
+    // freq stream still carries doc/freq deltas so TermQuery scoring works.
 
     threadState->p->lastPosition = position++;
 

--- a/src/core/CLucene/index/FieldInfos.cpp
+++ b/src/core/CLucene/index/FieldInfos.cpp
@@ -29,14 +29,16 @@ FieldInfo::FieldInfo(	const TCHAR* _fieldName,
 						const bool _storeOffsetWithTermVector,
 						const bool _storePositionWithTermVector,
 						const bool _omitNorms,
-						const bool _storePayloads):
+						const bool _storePayloads,
+						const bool _omitPositions):
 	name(CLStringIntern::intern(_fieldName )),
 	isIndexed(_isIndexed),
 	number(_fieldNumber),
 	storeTermVector(_storeTermVector),
 	storeOffsetWithTermVector(_storeOffsetWithTermVector),
 	storePositionWithTermVector(_storePositionWithTermVector),
-	omitNorms(_omitNorms), storePayloads(_storePayloads)
+	omitNorms(_omitNorms), storePayloads(_storePayloads),
+	omitPositions(_omitPositions)
 {
 }
 
@@ -46,7 +48,7 @@ FieldInfo::~FieldInfo(){
 
 FieldInfo* FieldInfo::clone() {
 	return _CLNEW FieldInfo(name, isIndexed, number, storeTermVector, storePositionWithTermVector,
-		storeOffsetWithTermVector, omitNorms, storePayloads);
+		storeOffsetWithTermVector, omitNorms, storePayloads, omitPositions);
 }
 
 FieldInfos::FieldInfos():
@@ -83,12 +85,17 @@ FieldInfos* FieldInfos::clone()
 }
 
 void FieldInfos::add(const Document* doc) {
+  add(doc, false);
+}
+
+void FieldInfos::add(const Document* doc, const bool forceOmitPositions) {
   const Document::FieldsType& fields = *doc->getFields();
 	Field* field;
   for ( Document::FieldsType::const_iterator itr = fields.begin() ; itr != fields.end() ; itr++ ){
 			field = *itr;
 			add(field->name(), field->isIndexed(), field->isTermVectorStored(), field->isStorePositionWithTermVector(),
-              field->isStoreOffsetWithTermVector(), field->getOmitNorms());
+              field->isStoreOffsetWithTermVector(), field->getOmitNorms(), /*storePayloads*/ false,
+              /*omitPositions*/ forceOmitPositions);
 	}
 }
 
@@ -114,12 +121,12 @@ void FieldInfos::add(const TCHAR** names,const bool isIndexed, const bool storeT
 
 FieldInfo* FieldInfos::add( const TCHAR* name, const bool isIndexed, const bool storeTermVector,
 		const bool storePositionWithTermVector, const bool storeOffsetWithTermVector, const bool omitNorms,
-		const bool storePayloads) {
+		const bool storePayloads, const bool omitPositions) {
 	FieldInfo* fi = fieldInfo(name);
 	if (fi == NULL) {
-		return addInternal(name, isIndexed, storeTermVector, 
-			storePositionWithTermVector, 
-			storeOffsetWithTermVector, omitNorms, storePayloads);
+		return addInternal(name, isIndexed, storeTermVector,
+			storePositionWithTermVector,
+			storeOffsetWithTermVector, omitNorms, storePayloads, omitPositions);
 	} else {
 		if (fi->isIndexed != isIndexed) {
 			fi->isIndexed = true;                      // once indexed, always index
@@ -139,19 +146,39 @@ FieldInfo* FieldInfos::add( const TCHAR* name, const bool isIndexed, const bool 
 		if (fi->storePayloads != storePayloads) {
 			fi->storePayloads = true;
 		}
+		// Sticky toward omit: as soon as any caller asks to omit positions,
+		// the merged FieldInfo also omits. We cannot synthesize positions
+		// for an input that lacks them, so a mixed merge must drop prox
+		// rather than crash later in appendPostings/SegmentTermPositions.
+		if (omitPositions && !fi->omitPositions) {
+			fi->omitPositions = true;
+			// Payloads are encoded inside the prox stream; drop the flag
+			// when prox is being dropped to keep FieldInfo self-consistent.
+			fi->storePayloads = false;
+		}
 	}
 	return fi;
 }
 
 FieldInfo* FieldInfos::addInternal( const TCHAR* name, const bool isIndexed, const bool storeTermVector,
 		const bool storePositionWithTermVector, const bool storeOffsetWithTermVector,
-		const bool omitNorms, const bool storePayloads) {
+		const bool omitNorms, const bool storePayloads, const bool omitPositions) {
 
-	FieldInfo* fi = _CLNEW FieldInfo(name, isIndexed, byNumber.size(), storeTermVector, 
-		storePositionWithTermVector, storeOffsetWithTermVector, omitNorms, storePayloads);
+	FieldInfo* fi = _CLNEW FieldInfo(name, isIndexed, byNumber.size(), storeTermVector,
+		storePositionWithTermVector, storeOffsetWithTermVector, omitNorms, storePayloads, omitPositions);
 	byNumber.push_back(fi);
 	byName.put( fi->name, fi);
 	return fi;
+}
+
+bool FieldInfos::hasProx() const {
+	const size_t n = size();
+	for (size_t i = 0; i < n; ++i) {
+		FieldInfo* fi = fieldInfo(static_cast<int32_t>(i));
+		if (fi != NULL && fi->isIndexed && !fi->omitPositions)
+			return true;
+	}
+	return false;
 }
 
 int32_t FieldInfos::fieldNumber(const TCHAR* fieldName)const {
@@ -210,6 +237,11 @@ void FieldInfos::write(IndexOutput* output) const{
  		if (fi->storeOffsetWithTermVector) bits |= STORE_OFFSET_WITH_TERMVECTOR;
  		if (fi->omitNorms) bits |= OMIT_NORMS;
 		if (fi->storePayloads) bits |= STORE_PAYLOADS;
+		// The OMIT_POSITIONS bit is forward-only: old readers ignore unknown
+		// bits, so they will simply treat the field as if positions were still
+		// indexed (and would fail when actually opening the missing .prx file).
+		// Default value of false keeps the on-disk byte identical to legacy.
+		if (fi->omitPositions) bits |= OMIT_POSITIONS;
 
 	    output->writeString(fi->name,_tcslen(fi->name));
 	    output->writeByte(bits);
@@ -219,7 +251,7 @@ void FieldInfos::write(IndexOutput* output) const{
 void FieldInfos::read(IndexInput* input) {
 	int32_t size = input->readVInt();//read in the size
     uint8_t bits;
-	bool isIndexed,storeTermVector,storePositionsWithTermVector,storeOffsetWithTermVector,omitNorms,storePayloads;
+	bool isIndexed,storeTermVector,storePositionsWithTermVector,storeOffsetWithTermVector,omitNorms,storePayloads,omitPositions;
 	for (int32_t i = 0; i < size; ++i){
 	    TCHAR* name = input->readString(); //we could read name into a string buffer, but we can't be sure what the maximum field length will be.
 		bits = input->readByte();
@@ -229,8 +261,9 @@ void FieldInfos::read(IndexInput* input) {
    		storeOffsetWithTermVector = (bits & STORE_OFFSET_WITH_TERMVECTOR) != 0;
    		omitNorms = (bits & OMIT_NORMS) != 0;
 		storePayloads = (bits & STORE_PAYLOADS) != 0;
-   
-   		addInternal(name, isIndexed, storeTermVector, storePositionsWithTermVector, storeOffsetWithTermVector, omitNorms, storePayloads);
+		omitPositions = (bits & OMIT_POSITIONS) != 0;
+
+		addInternal(name, isIndexed, storeTermVector, storePositionsWithTermVector, storeOffsetWithTermVector, omitNorms, storePayloads, omitPositions);
    		_CLDELETE_CARRAY(name);
 	}
 }

--- a/src/core/CLucene/index/IndexWriter.cpp
+++ b/src/core/CLucene/index/IndexWriter.cpp
@@ -133,6 +133,23 @@ void IndexWriter::setUseCompoundFile(bool value) {
   getLogMergePolicy()->setUseCompoundDocStore(value);
 }
 
+void IndexWriter::setOmitPositions(bool value) {
+  ensureOpen();
+  // Reject toggling once a session has data in flight to avoid producing
+  // inconsistent segments. Switching the flag after addDocument() could
+  // mix prox/no-prox postings within the same segment, which the on-disk
+  // layout cannot represent. Callers may always create a new IndexWriter
+  // to change this setting.
+  if (docWriter != NULL && docWriter->getNumDocsInRAM() > 0)
+    _CLTHROWA(CL_ERR_IllegalArgument,
+      "setOmitPositions must be called before any documents are added to this IndexWriter");
+  this->omitPositions = value;
+}
+
+bool IndexWriter::getOmitPositions() const {
+  return this->omitPositions;
+}
+
 void IndexWriter::setSimilarity(Similarity* similarity) {
   ensureOpen();
   this->similarity = similarity;
@@ -195,6 +212,7 @@ void IndexWriter::init(Directory* d, Analyzer* a, const bool create, const bool 
   maxFieldLength = FIELD_TRUNC_POLICY__WARN;
   infoStream = NULL;
   this->mergeFactor = this->minMergeDocs = this->maxMergeDocs = 0;
+  this->omitPositions = true;
   this->commitLockTimeout =0;
   this->closeDir = closeDir;
   this->commitPending = this->closed = this->closing = false;

--- a/src/core/CLucene/index/IndexWriter.h
+++ b/src/core/CLucene/index/IndexWriter.h
@@ -247,6 +247,14 @@ class CLUCENE_EXPORT IndexWriter:LUCENE_BASE {
   int32_t maxMergeDocs;
   int32_t termIndexInterval;
 
+  // When true, all newly-indexed fields will not have their term positions
+  // stored (i.e. no .prx file is produced for new segments). Defaults to
+  // true: by default this writer does NOT produce .prx files, which makes
+  // PhraseQuery / SpanQuery and other position-based queries unusable on
+  // newly-created segments. Call setOmitPositions(false) before adding any
+  // document if you need to keep proximity information.
+  bool omitPositions;
+
   int64_t writeLockTimeout;
   int64_t commitLockTimeout;
 
@@ -564,6 +572,34 @@ public:
    */
   void setUseCompoundFile(bool value);
 
+
+  /**
+   * Expert: If set to <code>true</code>, the IndexWriter will not write
+   * term position information (the .prx file) for any field added to this
+   * writer. This produces a smaller and faster-to-build index but disables
+   * queries that depend on positions such as {@link PhraseQuery} and
+   * {@link SpanQuery}; queries that only need document/frequency information
+   * (e.g. {@link TermQuery}, {@link BooleanQuery}, range queries) continue
+   * to work as before.
+   *
+   * <p>This setting is "sticky": it must be configured before any document
+   * is added to the writer, and is persisted into the segment so that
+   * merging segments with mixed settings keeps prox data only when at
+   * least one input segment indexed it.
+   *
+   * <p>The default is <code>true</code>: this writer does NOT emit .prx
+   * files unless you explicitly call <code>setOmitPositions(false)</code>
+   * before adding any document. Note that with the default, position-based
+   * queries (PhraseQuery, SpanQuery, etc.) cannot be executed on segments
+   * produced by this writer.
+   */
+  void setOmitPositions(bool value);
+
+  /**
+   * Returns the current setOmitPositions value.
+   * @see #setOmitPositions
+   */
+  bool getOmitPositions() const;
 
   /** Expert: Set the Similarity implementation used by this IndexWriter.
    *

--- a/src/core/CLucene/index/SegmentMerger.cpp
+++ b/src/core/CLucene/index/SegmentMerger.cpp
@@ -37,6 +37,10 @@ void SegmentMerger::init(){
   fieldInfos       = NULL;
   checkAbort       = NULL;
   skipInterval     = 0;
+  // Conservative default: when the constructor cannot consult an
+  // IndexWriter (e.g. the std::string overload that is never wired up),
+  // preserve historical behavior by keeping prox enabled.
+  omitPositionsForWriter = false;
 }
 
 SegmentMerger::SegmentMerger(IndexWriter* writer, const char* name, MergePolicy::OneMerge* merge){
@@ -55,6 +59,9 @@ SegmentMerger::SegmentMerger(IndexWriter* writer, const char* name, MergePolicy:
   this->termIndexInterval= writer->getTermIndexInterval();
   this->mergedDocs = 0;
   this->maxSkipLevels = 0;
+  // Capture the writer's omitPositions intent so the merger can drop prox
+  // from input segments when the writer has opted out of position storage.
+  this->omitPositionsForWriter = writer->getOmitPositions();
 }
 
 SegmentMerger::~SegmentMerger(){
@@ -155,10 +162,16 @@ void SegmentMerger::createCompoundFile(const char* filename, std::vector<std::st
   }
 
 	// Basic files
+  // .prx is conditionally produced; the writer omits it when every field
+  // has omitPositions=true. The compound-file builder bulk-includes any
+  // file we add here, so guard against listing a non-existent .prx.
+  const bool segmentHasProx = fieldInfos->hasProx();
   for (int32_t i = 0; i < IndexFileNames::COMPOUND_EXTENSIONS().length; i++) {
     const char* ext = IndexFileNames::COMPOUND_EXTENSIONS()[i];
     if (mergeDocStores || (strcmp(ext,IndexFileNames::FIELDS_EXTENSION) != 0 &&
         strcmp(ext,IndexFileNames::FIELDS_INDEX_EXTENSION) != 0 ) ){
+      if (!segmentHasProx && strcmp(ext, IndexFileNames::PROX_EXTENSION) == 0)
+        continue;
 		  files->push_back ( string(segment) + "." + ext );
     }
 	}
@@ -196,9 +209,20 @@ void SegmentMerger::addIndexed(IndexReader* reader, FieldInfos* fieldInfos, Stri
 
 	StringArrayWithDeletor::const_iterator itr = names.begin();
 	while ( itr != names.end() ){
+		// We are merging fields whose origin is a non-SegmentReader (e.g. a
+		// MultiReader) which does not surface omitPositions. If the writer
+		// requested omitPositions, force it here so the merged segment
+		// drops prox data and stays consistent with the writer's intent;
+		// otherwise preserve prox via false + the sticky-add rule.
+		const bool effectiveOmitPositions = omitPositionsForWriter;
+		// payloads require positions; drop them when positions are omitted
+		// to avoid producing a contradictory FieldInfo.
+		const bool effectiveStorePayloads =
+			storePayloads && !effectiveOmitPositions;
 		fieldInfos->add(*itr, true,
 			storeTermVectors, storePositionWithTermVector,
-			storeOffsetWithTermVector, !reader->hasNorms(*itr), storePayloads);
+			storeOffsetWithTermVector, !reader->hasNorms(*itr),
+			effectiveStorePayloads, effectiveOmitPositions);
 
 		++itr;
 	}
@@ -251,9 +275,22 @@ int32_t SegmentMerger::mergeFields() {
       SegmentReader* segmentReader = (SegmentReader*) reader;
       for (size_t j = 0; j < segmentReader->getFieldInfos()->size(); j++) {
         FieldInfo* fi = segmentReader->getFieldInfos()->fieldInfo(j);
+        // omitPositions resolution:
+        //  - writer asked to omit -> drop prox unconditionally for the
+        //    merged segment (overrides the sticky-add rule and discards
+        //    prox even from input segments that originally had it).
+        //  - writer did NOT ask to omit -> forward the input segment's
+        //    setting; the sticky-add rule then keeps prox alive when any
+        //    input segment still has it.
+        const bool effectiveOmitPositions =
+          omitPositionsForWriter ? true : fi->omitPositions;
+        // payloads need positions; clamp to false when we are stripping prox.
+        const bool effectiveStorePayloads =
+          fi->storePayloads && !effectiveOmitPositions;
         fieldInfos->add(fi->name, fi->isIndexed, fi->storeTermVector,
           fi->storePositionWithTermVector, fi->storeOffsetWithTermVector,
-          !reader->hasNorms(fi->name), fi->storePayloads);
+          !reader->hasNorms(fi->name), effectiveStorePayloads,
+          effectiveOmitPositions);
       }
     } else {
 	    StringArrayWithDeletor tmp;
@@ -429,8 +466,15 @@ void SegmentMerger::mergeTerms() {
       //Open an IndexOutput to the new Frequency File
       freqOutput = directory->createOutput( Misc::segmentname(segment.c_str(),".frq").c_str() );
 
-      //Open an IndexOutput to the new Prox File
-      proxOutput = directory->createOutput( Misc::segmentname(segment.c_str(),".prx").c_str() );
+      // Only open a prox stream when at least one field still indexes
+      // positions in the merged result. If every field in the merged
+      // FieldInfos has omitPositions=true, the merged segment will not
+      // contain a .prx file. SegmentInfo::files() uses dir->fileExists, so
+      // the absent file is handled transparently downstream.
+      if (fieldInfos->hasProx())
+        proxOutput = directory->createOutput( Misc::segmentname(segment.c_str(),".prx").c_str() );
+      else
+        proxOutput = NULL;
 
       //Instantiate  a new termInfosWriter which will write in directory
       //for the segment name segment using the new merged fieldInfos
@@ -441,6 +485,9 @@ void SegmentMerger::mergeTerms() {
 
       skipInterval = termInfosWriter->skipInterval;
       maxSkipLevels = termInfosWriter->maxSkipLevels;
+      // proxOutput may be NULL; DefaultSkipListWriter handles that and
+      // skips emitting the prox-pointer column, which matches what
+      // DefaultSkipListReader expects when initialized with omitPositions.
       skipListWriter = _CLNEW DefaultSkipListWriter(skipInterval, maxSkipLevels, mergedDocs, freqOutput, proxOutput);
       queue = _CLNEW SegmentMergeQueue(readers.size());
 
@@ -578,17 +625,16 @@ int32_t SegmentMerger::mergeTermInfo( SegmentMergeInfo** smis, int32_t n){
 //Pre  - smis != NULL and it contains segments that are positioned at the same term.
 //       n is equal to the number of SegmentMergeInfo instances in smis
 //       freqOutput != NULL
-//       proxOutput != NULL
+//       proxOutput may be NULL when the merged segment has no prox fields
 //Post - The TermInfo of a term has been merged
 
 	CND_PRECONDITION(smis != NULL, "smis is NULL");
 	CND_PRECONDITION(freqOutput != NULL, "freqOutput is NULL");
-	CND_PRECONDITION(proxOutput != NULL, "proxOutput is NULL");
 
   //Get the file pointer of the IndexOutput to the Frequency File
   int64_t freqPointer = freqOutput->getFilePointer();
-  //Get the file pointer of the IndexOutput to the Prox File
-  int64_t proxPointer = proxOutput->getFilePointer();
+  //Get the file pointer of the IndexOutput to the Prox File (0 when absent)
+  int64_t proxPointer = (proxOutput != NULL) ? proxOutput->getFilePointer() : 0;
 
   //Process postings from multiple segments all positioned on the same term.
   int32_t df = appendPostings(smis, n);
@@ -616,18 +662,23 @@ int32_t SegmentMerger::appendPostings(SegmentMergeInfo** smis, int32_t n){
 //Pre  - smis != NULL and it contains segments that are positioned at the same term.
 //       n is equal to the number of SegmentMergeInfo instances in smis
 //       freqOutput != NULL
-//       proxOutput != NULL
+//       proxOutput may be NULL when the merged field has omitPositions=true
 //Post - Returns number of documents across all segments where this term was found
 
   CND_PRECONDITION(smis != NULL, "smis is NULL");
   CND_PRECONDITION(freqOutput != NULL, "freqOutput is NULL");
-  CND_PRECONDITION(proxOutput != NULL, "proxOutput is NULL");
 
   int32_t lastDoc = 0;
   int32_t df = 0;       //Document Counter
 
   skipListWriter->resetSkip();
-  bool storePayloads = fieldInfos->fieldInfo(smis[0]->term->field())->storePayloads;
+  FieldInfo* fieldInfoForTerm = fieldInfos->fieldInfo(smis[0]->term->field());
+  // A field cannot both store payloads and omit positions; the writer-side
+  // FieldInfos enforces this when fields are added. We still defensively
+  // clamp storePayloads here so a malformed segment cannot trick us into
+  // writing payload metadata when the prox output is absent.
+  const bool fieldOmitPositions = (fieldInfoForTerm != NULL) && fieldInfoForTerm->omitPositions;
+  bool storePayloads = (fieldInfoForTerm != NULL) && fieldInfoForTerm->storePayloads && !fieldOmitPositions;
   int32_t lastPayloadLength = -1;   // ensures that we write the first length
 
   SegmentMergeInfo* smi = NULL;
@@ -689,32 +740,38 @@ int32_t SegmentMerger::appendPostings(SegmentMergeInfo** smis, int32_t n){
       /** See {@link DocumentWriter#writePostings(Posting[], String)} for
       *  documentation about the encoding of positions and payloads
       */
-      int32_t lastPosition = 0;
-      // write position deltas
-      for (int32_t j = 0; j < freq; j++) {
-        //Get the next position
-        int32_t position = postings->nextPosition();
-        int32_t delta = position - lastPosition;
-        if (storePayloads) {
-          size_t payloadLength = postings->getPayloadLength();
-          if (payloadLength == lastPayloadLength) {
-            proxOutput->writeVInt(delta * 2);
-          } else {
-            proxOutput->writeVInt(delta * 2 + 1);
-            proxOutput->writeVInt(payloadLength);
-            lastPayloadLength = payloadLength;
-          }
-          if (payloadLength > 0) {
-          	if ( payloadBuffer.length < payloadLength ){
-              payloadBuffer.resize(payloadLength);
+      // When the merged field omits positions the input segments also
+      // never recorded prox data, so postings->nextPosition() must not be
+      // invoked (it would attempt to read from a non-existent .prx stream
+      // on the input side). Likewise we have no proxOutput to write to.
+      if (!fieldOmitPositions) {
+        int32_t lastPosition = 0;
+        // write position deltas
+        for (int32_t j = 0; j < freq; j++) {
+          //Get the next position
+          int32_t position = postings->nextPosition();
+          int32_t delta = position - lastPosition;
+          if (storePayloads) {
+            size_t payloadLength = postings->getPayloadLength();
+            if (payloadLength == lastPayloadLength) {
+              proxOutput->writeVInt(delta * 2);
+            } else {
+              proxOutput->writeVInt(delta * 2 + 1);
+              proxOutput->writeVInt(payloadLength);
+              lastPayloadLength = payloadLength;
             }
-            postings->getPayload(payloadBuffer.values);
-            proxOutput->writeBytes(payloadBuffer.values, payloadLength);
+            if (payloadLength > 0) {
+              if ( payloadBuffer.length < payloadLength ){
+                payloadBuffer.resize(payloadLength);
+              }
+              postings->getPayload(payloadBuffer.values);
+              proxOutput->writeBytes(payloadBuffer.values, payloadLength);
+            }
+          } else {
+            proxOutput->writeVInt(delta);
           }
-        } else {
-          proxOutput->writeVInt(delta);
+          lastPosition = position;
         }
-        lastPosition = position;
       }
     }
   }

--- a/src/core/CLucene/index/SegmentReader.cpp
+++ b/src/core/CLucene/index/SegmentReader.cpp
@@ -197,6 +197,14 @@ CL_NS_DEF(index)
       // make sure that all index files have been read or are kept open
       // so that if an index update removes them we'll still have them
       freqStream = cfsDir->openInput( (segment + ".frq").c_str(), readBufferSize);
+      // Only open the prox stream when the segment actually contains a
+      // .prx file. When every indexed field has omitPositions=true the
+      // writer skipped creating it; opening here would raise IOException.
+      // SegmentTermPositions::nextPosition guards against use when null.
+      if (_fieldInfos->hasProx())
+        proxStream = cfsDir->openInput( (segment + ".prx").c_str(), readBufferSize);
+      else
+        proxStream = NULL;
       openNorms(cfsDir, readBufferSize);
 
       if (doOpenStores && _fieldInfos->hasVectors()) { // open term vector files only as needed

--- a/src/core/CLucene/index/SegmentTermDocs.cpp
+++ b/src/core/CLucene/index/SegmentTermDocs.cpp
@@ -16,7 +16,7 @@ CL_NS_DEF(index)
   SegmentTermDocs::SegmentTermDocs(const SegmentReader* _parent) : parent(_parent),freqStream(_parent->freqStream->clone()),
 		count(0),df(0),deletedDocs(_parent->deletedDocs),_doc(0),_freq(0),skipInterval(_parent->tis->getSkipInterval()),
 		maxSkipLevels(_parent->tis->getMaxSkipLevels()),skipListReader(NULL),freqBasePointer(0),proxBasePointer(0),
-		skipPointer(0),haveSkipped(false)
+		skipPointer(0),haveSkipped(false),currentFieldStoresPayloads(false),currentFieldOmitsPositions(false)
 	{
       CND_CONDITION(_parent != NULL,"Parent is NULL");
    }
@@ -57,6 +57,10 @@ CL_NS_DEF(index)
 	  count = 0;
 	  FieldInfo* fi = parent->_fieldInfos->fieldInfo(term->field());
 	  currentFieldStoresPayloads = (fi != NULL) ? fi->storePayloads : false;
+	  // Cache the field's omitPositions setting so that skipTo can forward it
+	  // to the skip list reader. The skip data layout differs based on this
+	  // bit (no proxPointer delta when positions are omitted).
+	  currentFieldOmitsPositions = (fi != NULL) ? fi->omitPositions : false;
 	  if (ti == NULL) {
 		  df = 0;
 	  } else {					// punt case
@@ -133,7 +137,7 @@ CL_NS_DEF(index)
 		  skipListReader = _CLNEW DefaultSkipListReader(freqStream->clone(), maxSkipLevels, skipInterval); // lazily clone
 
 	  if (!haveSkipped) {                          // lazily initialize skip stream
-		  skipListReader->init(skipPointer, freqBasePointer, proxBasePointer, df, currentFieldStoresPayloads);
+		  skipListReader->init(skipPointer, freqBasePointer, proxBasePointer, df, currentFieldStoresPayloads, currentFieldOmitsPositions);
 		  haveSkipped = true;
 	  }
 

--- a/src/core/CLucene/index/SegmentTermPositions.cpp
+++ b/src/core/CLucene/index/SegmentTermPositions.cpp
@@ -119,19 +119,29 @@ void SegmentTermPositions::skipPayload() {
 
 void SegmentTermPositions::lazySkip() {
     if (proxStream == NULL) {
+      // The parent SegmentReader did not open the .prx file because every
+      // indexed field in this segment has omitPositions=true. Position-based
+      // queries (PhraseQuery, SpanQuery) require this data and cannot run
+      // against such a field; fail loudly instead of crashing with a NPE so
+      // callers can detect the configuration mismatch immediately.
+      if (parent->proxStream == NULL) {
+        _CLTHROWA(CL_ERR_InvalidState,
+          "field was indexed with omitPositions=true; position-based queries "
+          "(e.g. PhraseQuery, SpanQuery) are not supported on this field");
+      }
       // clone lazily
       proxStream = parent->proxStream->clone();
     }
-    
+
     // we might have to skip the current payload
     // if it was not read yet
     skipPayload();
-      
+
     if (lazySkipPointer != -1) {
       proxStream->seek(lazySkipPointer);
       lazySkipPointer = -1;
     }
-     
+
     if (lazySkipProxCount != 0) {
       skipPositions(lazySkipProxCount);
       lazySkipProxCount = 0;

--- a/src/core/CLucene/index/SkipListReader.cpp
+++ b/src/core/CLucene/index/SkipListReader.cpp
@@ -247,25 +247,39 @@ DefaultSkipListReader::DefaultSkipListReader(CL_NS(store)::IndexInput* _skipStre
 {
 	freqPointer = _CL_NEWARRAY(int64_t,maxSkipLevels);
 	payloadLength = _CL_NEWARRAY(int32_t,maxSkipLevels);
+	proxPointer = _CL_NEWARRAY(int64_t,maxSkipLevels);
   memset(freqPointer,0, sizeof(int64_t) * maxSkipLevels);
+  memset(proxPointer,0, sizeof(int64_t) * maxSkipLevels);
   memset(payloadLength,0, sizeof(int32_t) * maxSkipLevels);
   this->lastFreqPointer = 0;
   this->lastPayloadLength = 0;
+  this->lastProxPointer = 0;
   this->currentFieldStoresPayloads = false;
+  this->currentFieldOmitsPositions = false;
 }
 
 DefaultSkipListReader::~DefaultSkipListReader(){
 	_CLDELETE_LARRAY(freqPointer);
+	_CLDELETE_LARRAY(proxPointer);
 	_CLDELETE_LARRAY(payloadLength);
 }
 
-void DefaultSkipListReader::init(const int64_t _skipPointer, const int64_t freqBasePointer, const int64_t proxBasePointer, const int32_t df, const bool storesPayloads) {
+void DefaultSkipListReader::init(const int64_t _skipPointer, const int64_t freqBasePointer, const int64_t proxBasePointer, const int32_t df, const bool storesPayloads, const bool omitPositions) {
 	MultiLevelSkipListReader::init(_skipPointer, df);
 	this->currentFieldStoresPayloads = storesPayloads;
+	// A field cannot both omit positions and store payloads (payloads ride
+	// inside the prox stream). Enforce this defensively to match the
+	// writer-side guarantee.
+	this->currentFieldOmitsPositions = omitPositions;
+	if (omitPositions) {
+		this->currentFieldStoresPayloads = false;
+	}
 	lastFreqPointer = freqBasePointer;
+	lastProxPointer = proxBasePointer;
 
 	for (int32_t j=0; j<maxNumberOfSkipLevels; j++){
 		freqPointer[j] = freqBasePointer;
+		proxPointer[j] = proxBasePointer;
 		payloadLength[j] = 0;
 	}
 }
@@ -274,7 +288,7 @@ int64_t DefaultSkipListReader::getFreqPointer() const {
 	return lastFreqPointer;
 }
 int64_t DefaultSkipListReader::getProxPointer() const {
-	return 0;
+	return lastProxPointer;
 }
 int32_t DefaultSkipListReader::getPayloadLength() const {
 	return lastPayloadLength;
@@ -283,12 +297,14 @@ int32_t DefaultSkipListReader::getPayloadLength() const {
 void DefaultSkipListReader::seekChild(const int32_t level) {
 	MultiLevelSkipListReader::seekChild(level);
 	freqPointer[level] = lastFreqPointer;
+	proxPointer[level] = lastProxPointer;
 	payloadLength[level] = lastPayloadLength;
 }
 
 void DefaultSkipListReader::setLastSkipData(const int32_t level) {
 	MultiLevelSkipListReader::setLastSkipData(level);
 	lastFreqPointer = freqPointer[level];
+	lastProxPointer = proxPointer[level];
 	lastPayloadLength = payloadLength[level];
 }
 
@@ -308,7 +324,12 @@ int32_t DefaultSkipListReader::readSkipData(const int32_t level, CL_NS(store)::I
 	} else {
 		delta = _skipStream->readVInt();
 	}
-	proxPointer[level] += _skipStream->readVInt();
+	freqPointer[level] += _skipStream->readVInt();
+	// Mirror DefaultSkipListWriter::writeSkipData: the prox delta is only
+	// written when the field stores positions. If omitted, leave the
+	// running pointer untouched so it stays at the freq base.
+	if (!currentFieldOmitsPositions)
+		proxPointer[level] += _skipStream->readVInt();
 
 	return delta;
 }

--- a/src/core/CLucene/index/SkipListWriter.cpp
+++ b/src/core/CLucene/index/SkipListWriter.cpp
@@ -95,6 +95,9 @@ void DefaultSkipListWriter::setSkipData(int32_t doc, bool storePayloads, int32_t
   this->curStorePayloads = storePayloads;
   this->curPayloadLength = payloadLength;
   this->curFreqPointer = freqOutput->getFilePointer();
+  // proxOutput is NULL when the field omits positions; the prox pointer is
+  // unused in that case (writeSkipData skips writing it as well).
+  this->curProxPointer = (proxOutput != NULL) ? proxOutput->getFilePointer() : 0;
 }
 
 void DefaultSkipListWriter::resetSkip() {
@@ -102,6 +105,10 @@ void DefaultSkipListWriter::resetSkip() {
   memset(lastSkipDoc, 0, numberOfSkipLevels * sizeof(int32_t) );
   Arrays<int32_t>::fill(lastSkipPayloadLength, numberOfSkipLevels, -1);  // we don't have to write the first length in the skip list
   Arrays<int64_t>::fill(lastSkipFreqPointer,   numberOfSkipLevels, freqOutput->getFilePointer());
+  // proxOutput may be NULL for omit-positions fields; mirror the value used
+  // by setSkipData/writeSkipData so the deltas remain zero.
+  Arrays<int64_t>::fill(lastSkipProxPointer, numberOfSkipLevels,
+                        (proxOutput != NULL) ? proxOutput->getFilePointer() : 0);
 }
 
 void DefaultSkipListWriter::writeSkipData(int32_t level, IndexOutput* skipBuffer){
@@ -143,7 +150,12 @@ void DefaultSkipListWriter::writeSkipData(int32_t level, IndexOutput* skipBuffer
     skipBuffer->writeVInt(curDoc - lastSkipDoc[level]);
   }
   skipBuffer->writeVInt((int32_t) (curFreqPointer - lastSkipFreqPointer[level]));
-  skipBuffer->writeVInt((int32_t) (curProxPointer - lastSkipProxPointer[level]));
+  // Only emit the prox delta when this field actually owns prox data. The
+  // matching reader (DefaultSkipListReader::readSkipData, initialized with
+  // omitPositions=true) skips reading this VInt in the same case so the
+  // skip-list payload stays byte-for-byte consistent.
+  if (proxOutput != NULL)
+    skipBuffer->writeVInt((int32_t) (curProxPointer - lastSkipProxPointer[level]));
 
   lastSkipDoc[level] = curDoc;
   //System.out.println("write doc at level " + level + ": " + curDoc);

--- a/src/core/CLucene/index/_FieldInfos.h
+++ b/src/core/CLucene/index/_FieldInfos.h
@@ -34,6 +34,12 @@ class FieldInfo :LUCENE_BASE{
 
 	bool storePayloads; // whether this field stores payloads together with term positions
 
+	// If true, term positions are not indexed for this field (the .prx file
+	// will not contain entries for it). This trades off the ability to run
+	// PhraseQuery/SpanQuery against this field for a smaller index and faster
+	// indexing. Defaults to false to preserve full backward compatibility.
+	bool omitPositions;
+
 	//Func - Constructor
 	//       Initialises FieldInfo.
 	//       na holds the name of the field
@@ -53,7 +59,8 @@ class FieldInfo :LUCENE_BASE{
 		const bool storeOffsetWithTermVector,
 		const bool storePositionWithTermVector,
 		const bool omitNorms,
-		const bool storePayloads);
+		const bool storePayloads,
+		const bool omitPositions = false);
 
     //Func - Destructor
 	//Pre  - true
@@ -87,7 +94,10 @@ public:
 		STORE_POSITIONS_WITH_TERMVECTOR = 0x4,
 		STORE_OFFSET_WITH_TERMVECTOR = 0x8,
 		OMIT_NORMS = 0x10,
-		STORE_PAYLOADS = 0x20
+		STORE_PAYLOADS = 0x20,
+		// Bit indicating that term positions are not stored for this field.
+		// When set, the segment will not contain prox data for this field.
+		OMIT_POSITIONS = 0x40
 	};
 
 	FieldInfos();
@@ -110,6 +120,11 @@ public:
 
 	/** Adds field info for a Document. */
 	void add(const CL_NS(document)::Document* doc);
+
+	/** Adds field info for a Document, forcing all fields to omit positions
+	 *  when forceOmitPositions is true. Used by IndexWriter when
+	 *  setOmitPositions(true) is in effect. */
+	void add(const CL_NS(document)::Document* doc, const bool forceOmitPositions);
 
 	/**
 	* Add fields that are indexed. Whether they have termvectors has to be specified.
@@ -150,11 +165,16 @@ public:
 	* @param storePayloads true if payloads should be stored for this field
 	*/
 	FieldInfo* add(const TCHAR* name, const bool isIndexed, const bool storeTermVector=false,
-	          const bool storePositionWithTermVector=false, const bool storeOffsetWithTermVector=false, const bool omitNorms=false, const bool storePayloads=false);
+	          const bool storePositionWithTermVector=false, const bool storeOffsetWithTermVector=false, const bool omitNorms=false, const bool storePayloads=false, const bool omitPositions=false);
 
 	// was void
 	FieldInfo* addInternal( const TCHAR* name,const bool isIndexed, const bool storeTermVector,
-		const bool storePositionWithTermVector, const bool storeOffsetWithTermVector, const bool omitNorms, const bool storePayloads);
+		const bool storePositionWithTermVector, const bool storeOffsetWithTermVector, const bool omitNorms, const bool storePayloads, const bool omitPositions = false);
+
+	/** Returns true when the segment described by this FieldInfos
+	 *  has at least one indexed field that still stores positions
+	 *  (i.e. requires a .prx file). */
+	bool hasProx() const;
 
 	int32_t fieldNumber(const TCHAR* fieldName)const;
 	

--- a/src/core/CLucene/index/_SegmentHeader.h
+++ b/src/core/CLucene/index/_SegmentHeader.h
@@ -52,6 +52,10 @@ private:
 
 protected:
   bool currentFieldStoresPayloads;
+  // Mirrors FieldInfo::omitPositions for the currently-seeked term. Used by
+  // SegmentTermDocs::skipTo to configure DefaultSkipListReader so the skip
+  // stream is decoded with the correct layout (no prox VInt per entry).
+  bool currentFieldOmitsPositions;
 
 public:
   ///\param Parent must be a segment reader

--- a/src/core/CLucene/index/_SegmentMerger.h
+++ b/src/core/CLucene/index/_SegmentMerger.h
@@ -69,6 +69,12 @@ class SegmentMerger:LUCENE_BASE {
   int32_t maxSkipLevels;
   DefaultSkipListWriter* skipListWriter;
 
+  // Snapshot of the originating IndexWriter's omitPositions setting. When
+  // true the merged segment will not produce a .prx file, even if input
+  // segments contained position data (prox is dropped on purpose, matching
+  // the writer's stated preference).
+  bool omitPositionsForWriter;
+
 public:
   static const uint8_t NORMS_HEADER[]; 
   static const int NORMS_HEADER_length;

--- a/src/core/CLucene/index/_SkipListReader.h
+++ b/src/core/CLucene/index/_SkipListReader.h
@@ -142,6 +142,9 @@ protected:
 class DefaultSkipListReader: public MultiLevelSkipListReader {
 private:
 	bool currentFieldStoresPayloads;
+	// When true, the underlying field omits term positions and the skip
+	// data stream does not contain a proxPointer delta per entry.
+	bool currentFieldOmitsPositions;
 	int64_t* freqPointer;
 	int64_t* proxPointer;
 	int32_t* payloadLength;
@@ -154,7 +157,7 @@ public:
 	DefaultSkipListReader(CL_NS(store)::IndexInput* _skipStream, const int32_t maxSkipLevels, const int32_t _skipInterval);
 	virtual ~DefaultSkipListReader();
 
-	void init(const int64_t _skipPointer, const int64_t freqBasePointer, const int64_t proxBasePointer, const int32_t df, const bool storesPayloads);
+	void init(const int64_t _skipPointer, const int64_t freqBasePointer, const int64_t proxBasePointer, const int32_t df, const bool storesPayloads, const bool omitPositions = false);
 
 	/** Returns the freq pointer of the doc to which the last call of
 	* {@link MultiLevelSkipListReader#skipTo(int)} has skipped.  */

--- a/src/core/CLucene/search/PhraseQuery.cpp
+++ b/src/core/CLucene/search/PhraseQuery.cpp
@@ -204,7 +204,13 @@ CL_NS_DEF(search)
 			Query* termQuery = _CLNEW TermQuery(term);
 			termQuery->setBoost(getBoost());
 			Weight* ret = termQuery->_createWeight(searcher);
-			_CLLDELETE(termQuery);
+			// Ownership of termQuery is transferred to the returned TermWeight,
+			// which stores it as parentQuery. Deleting it here would leave the
+			// TermWeight with a dangling pointer and cause a double-free in
+			// IndexSearcher::_search, which itself frees weight->getQuery() when
+			// it differs from the original query (the "rewrite" cleanup path).
+			// So we intentionally do NOT delete termQuery here; the searcher
+			// will free it through that cleanup path once the search completes.
 			return ret;
 		}
 		return _CLNEW PhraseWeight(searcher,this);


### PR DESCRIPTION
## Add `IndexWriter::setOmitPositions` toggle for `.prx` generation

### Background

CLucene currently writes the `.prx` (term position) file unconditionally for every segment. In workloads that do not need phrase / span queries, this data is pure overhead in index size. This PR introduces an opt-in toggle so the caller can control whether `.prx` is produced.

### What changes

1. **New `IndexWriter::setOmitPositions(bool)` API**
   - Default is `true`: newly written segments do **not** produce a `.prx` file.
   - Must be called before the first `addDocument()`; calling it later throws `CL_ERR_IllegalArgument`.
   - The flag is persisted in `.fnm` via a new `OMIT_POSITIONS = 0x40` bit.
   - `SegmentReader`, `SegmentMerger` and the compound-file builder all key off `FieldInfos::hasProx()`, so a missing `.prx` is handled transparently. Reading existing indexes is unaffected.
   - During merge, the writer's `omitPositions` setting overrides per-segment values to avoid attempts to read prox data that does not exist in mixed segments.

2. **Position-write path preserved**
   - When `omitPositions=false`, `DocumentsWriter` / `SkipListWriter` still emit positions and prox pointers correctly, so PhraseQuery / SpanQuery keep working on prox-enabled segments.

### Compatibility

- **Default behavior change**: new writers no longer emit `.prx` by default. Callers that need phrase / span queries must explicitly call `writer->setOmitPositions(false)` before adding any document.
- **Reading old indexes**: fully compatible. Old `.fnm` files lack the `OMIT_POSITIONS` bit and are interpreted as "prox enabled", which matches their actual on-disk layout.
- **`.fnm` format forward/backward compatibility**: the new bit is set only by new writers; old readers ignore unknown bits and behave as before.
- **Query behavior on omit segments**: PhraseQuery / SpanQuery on an omit-positions field throws `CL_ERR_InvalidState`, allowing the caller to detect the configuration explicitly instead of silently returning wrong results.

### Usage

```cpp
IndexWriter* writer = _CLNEW IndexWriter(directory, analyzer, true);

// Default: no .prx produced. TermQuery / BooleanQuery and TF-IDF scoring work normally.
writer->addDocument(doc);

// To enable PhraseQuery, disable omit BEFORE the first addDocument().
writer->setOmitPositions(false);
writer->addDocument(doc);
```

### Scope

| File | Purpose |
|---|---|
| `index/IndexWriter.{h,cpp}` | New `setOmitPositions` / `getOmitPositions` API |
| `index/_FieldInfos.h`, `index/FieldInfos.cpp` | Persist `omitPositions`; sticky-add rule favors omit |
| `index/DocumentsWriter*.cpp` | Conditionally allocate prox slices and write `.prx` |
| `index/SegmentMerger.{h,cpp}` | Override per-segment omit with writer's setting during merge |
| `index/SegmentReader.cpp`, `index/SegmentTermPositions.cpp` | Skip opening `.prx` when not present; explicit error for position-based queries |
| `index/SegmentTermDocs.cpp`, `index/SkipList{Reader,Writer}.cpp`, `index/_SkipListReader.h`, `index/_SegmentHeader.h` | Skip the prox-pointer column in skip lists when positions are omitted |

### Testing

Built a RAM index with SimpleAnalyzer and verified:

- Default omit: segment on disk has no `.prx`; TermQuery / BooleanQuery return expected hits; PhraseQuery raises the expected exception.
- Explicit `setOmitPositions(false)`: segment includes `.prx`; PhraseQuery returns expected hits.
- Opening and querying pre-existing indexes (with `.prx`) is unchanged.



Hi @srlch, could you please help review this PR? I have implemented match_phrase and tested it in our environment based on these changes. Everything works well.