### PR TITLE
[BugFix] Fix buffer overflow in CJK analyzer

### DIFF
--- a/src/contribs-lib/CLucene/analysis/cjk/CJKAnalyzer.cpp
+++ b/src/contribs-lib/CLucene/analysis/cjk/CJKAnalyzer.cpp
@@ -119,6 +119,9 @@ CL_NS(analysis)::Token* CJKTokenizer::next(Token* token){
 
                 // break the procedure if buffer overflowed!
                 if (length == LUCENE_MAX_WORD_LEN) {
+                    offset -= charlen;
+                    bufferIndex -= charlen;
+                    length--;
                     break;
                 }
             } else if (length > 0) {

--- a/src/contribs/contribs-lib-test/TestAnalysis.cpp
+++ b/src/contribs/contribs-lib-test/TestAnalysis.cpp
@@ -143,6 +143,9 @@ void testCJK(CuTest *tc) {
 
     static const char* exp2[6] = {"a", "\xe5\x95\xa4\xe9\x85\x92", "\xe9\x85\x92\xe5\x95\xa4", "", "x", NULL};
     _testCJK(tc, "a\xe5\x95\xa4\xe9\x85\x92\xe5\x95\xa4x", exp2);
+
+    static const char* exp4[4] = {"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "abbb", NULL};
+    _testCJK(tc, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbb", exp4);
 }
 
 void testLanguageBasedAnalyzer(CuTest* tc) {


### PR DESCRIPTION
* When word length reaches LUCENE_MAX_WORD_LEN, truncate the string to avoid buffer overflow.
* Add test case to verify handling of extremely long strings.

Fixed: [存算一体 3.5.6 版本，采用倒排索引的表，插入数据后be宕机](https://github.com/StarRocks/starrocks/issues/63932)