### PR TITLE
[BugFix] Fix CLucene skip list reader crash in starrocks:match_all

### DIFF
--- a/src/core/CLucene/index/SkipListReader.cpp
+++ b/src/core/CLucene/index/SkipListReader.cpp
@@ -308,7 +308,11 @@ int32_t DefaultSkipListReader::readSkipData(const int32_t level, CL_NS(store)::I
 	} else {
 		delta = _skipStream->readVInt();
 	}
-	proxPointer[level] += _skipStream->readVInt();
+	// Must match DefaultSkipListWriter::writeSkipData: DocSkip [, PayloadLength?], FreqSkip, ProxSkip.
+	// Accumulate FreqSkip in freqPointer for freqStream->seek() after skipTo(); consume ProxSkip to
+	// keep the skip stream aligned (proxPointer is not allocated on the term-docs path).
+	freqPointer[level] += _skipStream->readVInt();
+	_skipStream->readVInt();
 
 	return delta;
 }

--- a/src/test/CLMonolithic_Test.cpp
+++ b/src/test/CLMonolithic_Test.cpp
@@ -45,6 +45,7 @@
 #include "search/spans/TestSpansAdvanced.cpp"
 #include "search/spans/TestSpans.cpp"
 #include "search/TestBoolean.cpp"
+#include "search/TestMatchAll.cpp"
 #include "search/TestConstantScoreRangeQuery.cpp"
 #include "search/TestDateFilter.cpp"
 #include "search/TestExplanations.cpp"

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -48,6 +48,7 @@ SET(test_files ./tests.cpp
 ./search/MockScorer.h
 ./search/MockHitCollector.h
 ./search/TestBoolean.cpp
+./search/TestMatchAll.cpp
 ./search/TestDateFilter.cpp
 ./search/TestForDuplicates.cpp
 ./search/TestQueries.cpp

--- a/src/test/search/TestMatchAll.cpp
+++ b/src/test/search/TestMatchAll.cpp
@@ -1,0 +1,71 @@
+/*------------------------------------------------------------------------------
+ * Regression test for StarRocks-style match_all (Boolean AND of terms).
+ * Exercises ConjunctionScorer::skipTo -> SegmentTermDocs -> DefaultSkipListReader.
+ *------------------------------------------------------------------------------*/
+#include "test.h"
+#include "QueryUtils.h"
+#include "CheckHits.h"
+#include "CLucene/analysis/Analyzers.h"
+#include "CLucene/index/MergePolicy.h"
+#include "CLucene/search/BooleanQuery.h"
+
+CL_NS_USE(analysis)
+CL_NS_USE(document)
+CL_NS_USE(index)
+CL_NS_USE(search)
+CL_NS_USE(store)
+
+static void testMatchAllSparseIntersectionEvery40(CuTest* tc) {
+	const int32_t numDocs = 200;
+	const int32_t bothEvery = 40;
+
+	RAMDirectory dir;
+	WhitespaceAnalyzer analyzer;
+	IndexWriter writer(&dir, &analyzer, true);
+	writer.setMergePolicy(_CLNEW LogDocMergePolicy());
+	writer.setMaxBufferedDocs(1000);
+
+	Document doc;
+	for (int32_t i = 0; i < numDocs; i++) {
+		doc.clear();
+		const TCHAR* text;
+		if ((i % bothEvery) == 0) {
+			text = _T("termA termB");
+		} else if ((i % 2) == 0) {
+			text = _T("termA");
+		} else {
+			text = _T("termB");
+		}
+		doc.add(*_CLNEW Field(_T("content"), text, Field::STORE_NO | Field::INDEX_TOKENIZED));
+		writer.addDocument(&doc);
+	}
+	writer.close();
+
+	IndexSearcher searcher(&dir);
+	Term termA(_T("content"), _T("termA"));
+	Term termB(_T("content"), _T("termB"));
+	assertEquals(100, searcher.getReader()->docFreq(&termA));
+	assertEquals(105, searcher.getReader()->docFreq(&termB));	
+
+	// equivalent to match_all 'termA termB'
+	Term* tA = _CLNEW Term(_T("content"), _T("termA"));
+	Term* tB = _CLNEW Term(_T("content"), _T("termB"));
+	BooleanQuery* query = _CLNEW BooleanQuery();
+	query->add(_CLNEW TermQuery(tA), true, BooleanClause::MUST);
+	query->add(_CLNEW TermQuery(tB), true, BooleanClause::MUST);
+	_CLDECDELETE(tA);
+	_CLDECDELETE(tB);
+
+	const int32_t expectedCount = 5;
+	int32_t expected[5] = {0, 40, 80, 120, 160};
+	CheckHits::checkHitCollector(tc, query, _T("content"), &searcher, expected, (size_t)expectedCount);
+
+	_CLDELETE(query);
+	searcher.close();
+}
+
+CuSuite* testMatchAll(void) {
+	CuSuite* suite = CuSuiteNew(_T("CLucene MatchAll (Boolean AND) Test"));
+	SUITE_ADD_TEST(suite, testMatchAllSparseIntersectionEvery40);
+	return suite;
+}

--- a/src/test/search/TestMatchAll.cpp
+++ b/src/test/search/TestMatchAll.cpp
@@ -3,7 +3,6 @@
  * Exercises ConjunctionScorer::skipTo -> SegmentTermDocs -> DefaultSkipListReader.
  *------------------------------------------------------------------------------*/
 #include "test.h"
-#include "QueryUtils.h"
 #include "CheckHits.h"
 #include "CLucene/analysis/Analyzers.h"
 #include "CLucene/index/MergePolicy.h"

--- a/src/test/test.h
+++ b/src/test/test.h
@@ -73,6 +73,7 @@ CuSuite *testField(void);
 CuSuite *testNumberTools(void);
 CuSuite *testDateTools(void);
 CuSuite *testBoolean(void);
+CuSuite *testMatchAll(void);
 CuSuite *testBitSet(void);
 CuSuite *testExtractTerms(void);
 CuSuite *testSpanQueries(void);

--- a/src/test/tests.cpp
+++ b/src/test/tests.cpp
@@ -27,6 +27,7 @@ unittest tests[] = {
     {"queryparser", testQueryParser},
     {"mfqueryparser", testMultiFieldQueryParser},
     {"boolean", testBoolean},
+    {"matchall", testMatchAll},
     {"search", testsearch},
     {"rangefilter", testRangeFilter},
     {"queries", testqueries},


### PR DESCRIPTION
[CLucene PR #3](https://github.com/StarRocks/clucene/pull/3) removed **proxPointer** allocation but left code accessing it → NULL pointer crash when document frequency ≥ 16. This PR fixes backend crash in starrocks:match_all queries on inverted indexes with large lists.

## Test Plan

file: https://raw.githubusercontent.com/zygmuntz/goodbooks-10k/refs/heads/master/books.csv
```
ADMIN SET FRONTEND CONFIG ("enable_experimental_gin" = "true");

CREATE TABLE books (
    book_id BIGINT NOT NULL,
    title STRING,
    INDEX idx_title (title) USING GIN ("parser" = "english")
)
ENGINE=OLAP
DUPLICATE KEY(book_id)
DISTRIBUTED BY HASH(book_id) BUCKETS 8
PROPERTIES (
    "replication_num" = "1"
);

INSERT INTO books (book_id, title)
SELECT
    CAST($1 AS BIGINT),
    $11
FROM FILES(
    "path" = "file:///tmp/books.csv",
    "format" = "csv",
    "csv.skip_header" = "1",
    "csv.column_separator" = ",",
    "csv.enclose" = "\""
);
```

### before this change
```
mysql> select * from test.books where title match_all 'day and';
ERROR 1064 (HY000): Backend node not found. Check if any backend node is down.backend: [127.0.0.1 alive: true inBlacklist: true]
```

### after this change
```
mysql> select * from test.books where title match_all 'day and';
+---------+-------------------------------------------------------------+
| book_id | title                                                       |
+---------+-------------------------------------------------------------+
|    1835 | The Devil and Miss Prym (On the Seventh Day, #3)            |
|     661 | Alexander and the Terrible, Horrible, No Good, Very Bad Day |
+---------+-------------------------------------------------------------+
2 rows in set (0.02 sec)
```